### PR TITLE
Allow email field to be empty in allowedUsers file

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -28,6 +28,8 @@ func AuthReady() bool {
 	return (filename != "")
 }
 
+// Returns bcrypt-hash, email
+// email can be empty in which case it is not checked
 func AuthFetch(username string) (string, string, error) {
 	if !AuthReady() {
 		return "", "", errors.New("Authentication file not specified. Call LoadFile() first")
@@ -43,13 +45,22 @@ func AuthFetch(username string) (string, string, error) {
 	for scanner.Scan() {
 		parts := strings.Fields(scanner.Text())
 
-		if len(parts) != 3 {
+		if len(parts) < 2 || len(parts) > 3 {
 			continue
 		}
 
-		if strings.ToLower(username) == strings.ToLower(parts[0]) {
-			return parts[1], parts[2], nil
+		if strings.ToLower(username) != strings.ToLower(parts[0]) {
+			continue
 		}
+
+		hash := parts[1]
+		email := ""
+
+		if len(parts) >= 3 {
+			email = parts[2]
+		}
+
+		return hash, email, nil
 	}
 
 	return "", "", errors.New("User not found")

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func senderChecker(peer smtpd.Peer, addr string) error {
 			return smtpd.Error{Code: 451, Message: "Bad sender address"}
 		}
 
-		if strings.ToLower(addr) != strings.ToLower(email) {
+		if email != "" && strings.ToLower(addr) != strings.ToLower(email) {
 			return smtpd.Error{Code: 451, Message: "Bad sender address"}
 		}
 	}

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -37,7 +37,7 @@
 
 ; File which contains username and password used for
 ; authentication before they can send mail.
-; File format: username bcrypt-hash email
+; File format: username bcrypt-hash [email]
 ;allowed_users =
 
 ; Relay all mails to this SMTP server


### PR DESCRIPTION
I have a use case where I want to allow a client to send mail as more than just a single address, but still be required to login with username+password.

This PR allows the "email" field of the `allowedUsers` file (which was luckily the last field) to be missing. In this case, the check in `senderChecker` is skipped.