### PR TITLE
Expand allowedUsers email field to support comma-separated and domains

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -34,6 +34,12 @@ func AuthReady() bool {
 	return (filename != "")
 }
 
+// Split a string and ignore empty results
+// https://stackoverflow.com/a/46798310/119527
+func splitstr(s string, sep rune) []string {
+	return strings.FieldsFunc(s, func(c rune) bool { return c == sep })
+}
+
 func parseLine(line string) *AuthUser {
 	parts := strings.Fields(line)
 
@@ -48,7 +54,7 @@ func parseLine(line string) *AuthUser {
 	}
 
 	if len(parts) >= 3 {
-		user.allowedAddresses = strings.Split(parts[2], ",")
+		user.allowedAddresses = splitstr(parts[2], ',')
 	}
 
 	return &user

--- a/auth.go
+++ b/auth.go
@@ -30,14 +30,14 @@ func AuthReady() bool {
 
 // Returns bcrypt-hash, email
 // email can be empty in which case it is not checked
-func AuthFetch(username string) (string, string, error) {
+func AuthFetch(username string) (string, []string, error) {
 	if !AuthReady() {
-		return "", "", errors.New("Authentication file not specified. Call LoadFile() first")
+		return "", nil, errors.New("Authentication file not specified. Call LoadFile() first")
 	}
 
 	file, err := os.Open(filename)
 	if err != nil {
-		return "", "", err
+		return "", nil, err
 	}
 	defer file.Close()
 
@@ -54,16 +54,16 @@ func AuthFetch(username string) (string, string, error) {
 		}
 
 		hash := parts[1]
-		email := ""
+		email := []string(nil)
 
 		if len(parts) >= 3 {
-			email = parts[2]
+			email = strings.Split(parts[2], ",")
 		}
 
 		return hash, email, nil
 	}
 
-	return "", "", errors.New("User not found")
+	return "", nil, errors.New("User not found")
 }
 
 func AuthCheckPassword(username string, secret string) error {

--- a/auth_test.go
+++ b/auth_test.go
@@ -59,9 +59,9 @@ func TestParseLine(t *testing.T) {
 		},
 		{
 			name: "Multiple allowed addrs",
-			line: "joe xxx joe@example.com,foo.example.com",
+			line: "joe xxx joe@example.com,@foo.example.com",
 			username: "joe",
-			addrs: []string{"joe@example.com", "foo.example.com"},
+			addrs: []string{"joe@example.com", "@foo.example.com"},
 		},
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"testing"
+)
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, _ := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestParseLine(t *testing.T) {
+	var tests = []struct {
+		name string
+		expectFail bool
+		line string
+		username string
+		addrs []string
+	}{
+		{
+			name: "Empty line",
+			expectFail: true,
+			line: "",
+		},
+		{
+			name: "Too few fields",
+			expectFail: true,
+			line: "joe",
+		},
+		{
+			name: "Too many fields",
+			expectFail: true,
+			line: "joe xxx joe@example.com whatsthis",
+		},
+		{
+			name: "Normal case",
+			line: "joe xxx joe@example.com",
+			username: "joe",
+			addrs: []string{"joe@example.com"},
+		},
+		{
+			name: "No allowed addrs given",
+			line: "joe xxx",
+			username: "joe",
+			addrs: []string{},
+		},
+		{
+			name: "Trailing comma",
+			line: "joe xxx joe@example.com,",
+			username: "joe",
+			addrs: []string{"joe@example.com"},
+		},
+		{
+			name: "Multiple allowed addrs",
+			line: "joe xxx joe@example.com,foo.example.com",
+			username: "joe",
+			addrs: []string{"joe@example.com", "foo.example.com"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			user := parseLine(test.line)
+			if user == nil {
+				if !test.expectFail {
+					t.Errorf("parseLine() returned nil unexpectedly")
+				}
+				return
+			}
+
+			if user.username != test.username {
+				t.Errorf("Testcase %d: Incorrect username: expected %v, got %v",
+						 i, test.username, user.username)
+			}
+
+			if !stringsEqual(user.allowedAddresses, test.addrs) {
+				t.Errorf("Testcase %d: Incorrect addresses: expected %v, got %v",
+						 i, test.addrs, user.allowedAddresses)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ func addrAllowed(addr string, allowedAddrs []string) bool {
 		return true
 	}
 
+	addr = strings.ToLower(addr)
+
 	domidx := strings.LastIndex(addr, "@")
 	if domidx == -1 {
 		return false

--- a/main.go
+++ b/main.go
@@ -38,27 +38,40 @@ func connectionChecker(peer smtpd.Peer) error {
 
 func addrAllowed(addr string, allowedAddrs []string) bool {
 	if allowedAddrs == nil {
+		// If absent, all addresses are allowed
 		return true
 	}
 
 	addr = strings.ToLower(addr)
 
-	domidx := strings.LastIndex(addr, "@")
-	if domidx == -1 {
-		return false
+	// Extract optional domain part
+	domain := ""
+	if idx := strings.LastIndex(addr, "@"); idx != -1 {
+		domain = strings.ToLower(addr[idx+1:])
 	}
-	domain := strings.ToLower(addr[domidx+1:])
 
+	// Test each address from allowedUsers file
 	for _, allowedAddr := range allowedAddrs {
 		allowedAddr = strings.ToLower(allowedAddr)
 
-		if strings.Index(allowedAddr, "@") == -1 {
-			if allowedAddr == domain {
+		// Three cases for allowedAddr format:
+		if idx := strings.Index(allowedAddr, "@"); idx == -1 {
+			// 1. local address (no @) -- must match exactly
+			if allowedAddr == addr {
 				return true
 			}
 		} else {
-			if allowedAddr == addr {
-				return true
+			if idx != 0 {
+				// 2. email address (user@domain.com) -- must match exactly
+				if allowedAddr == addr {
+					return true
+				}
+			} else {
+				// 3. domain (@domain.com) -- must match addr domain
+				allowedDomain := allowedAddr[idx+1:]
+				if allowedDomain == domain {
+					return true
+				}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -67,12 +67,12 @@ func addrAllowed(addr string, allowedAddrs []string) bool {
 func senderChecker(peer smtpd.Peer, addr string) error {
 	// check sender address from auth file if user is authenticated
 	if *allowedUsers != "" && peer.Username != "" {
-		_, allowedAddrs, err := AuthFetch(peer.Username)
+		user, err := AuthFetch(peer.Username)
 		if err != nil {
 			return smtpd.Error{Code: 451, Message: "Bad sender address"}
 		}
 
-		if !addrAllowed(addr, allowedAddrs) {
+		if !addrAllowed(addr, user.allowedAddresses) {
 			return smtpd.Error{Code: 451, Message: "Bad sender address"}
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestAddrAllowedNoDomain(t *testing.T) {
+	allowedAddrs := []string{"joe@abc.com"}
+	if addrAllowed("bob.com", allowedAddrs) {
+		t.FailNow()
+	}
+}
+
+func TestAddrAllowedSingle(t *testing.T) {
+	allowedAddrs := []string{"joe@abc.com"}
+
+	if !addrAllowed("joe@abc.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if addrAllowed("bob@abc.com", allowedAddrs) {
+		t.FailNow()
+	}
+}
+
+func TestAddrAllowedMulti(t *testing.T) {
+	allowedAddrs := []string{"joe@abc.com", "bob@def.com"}
+	if !addrAllowed("joe@abc.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if !addrAllowed("bob@def.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if addrAllowed("bob@abc.com", allowedAddrs) {
+		t.FailNow()
+	}
+}
+
+func TestAddrAllowedSingleDomain(t *testing.T) {
+	allowedAddrs := []string{"abc.com"}
+	if !addrAllowed("joe@abc.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if addrAllowed("joe@def.com", allowedAddrs) {
+		t.FailNow()
+	}
+}
+
+func TestAddrAllowedMixed(t *testing.T) {
+	allowedAddrs := []string{"app@example.com", "appsrv.example.com"}
+	if !addrAllowed("app@example.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if addrAllowed("ceo@example.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if !addrAllowed("root@appsrv.example.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if !addrAllowed("dev@appsrv.example.com", allowedAddrs) {
+		t.FailNow()
+	}
+	if addrAllowed("appsrv@example.com", allowedAddrs) {
+		t.FailNow()
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,17 @@ func TestAddrAllowedDifferentCase(t *testing.T) {
     }
 }
 
+func TestAddrAllowedLocal(t *testing.T) {
+	allowedAddrs := []string{"joe"}
+
+	if !addrAllowed("joe", allowedAddrs) {
+		t.FailNow()
+	}
+	if addrAllowed("bob", allowedAddrs) {
+		t.FailNow()
+	}
+}
+
 func TestAddrAllowedMulti(t *testing.T) {
 	allowedAddrs := []string{"joe@abc.com", "bob@def.com"}
 	if !addrAllowed("joe@abc.com", allowedAddrs) {
@@ -51,7 +62,7 @@ func TestAddrAllowedMulti(t *testing.T) {
 }
 
 func TestAddrAllowedSingleDomain(t *testing.T) {
-	allowedAddrs := []string{"abc.com"}
+	allowedAddrs := []string{"@abc.com"}
 	if !addrAllowed("joe@abc.com", allowedAddrs) {
 		t.FailNow()
 	}
@@ -61,7 +72,10 @@ func TestAddrAllowedSingleDomain(t *testing.T) {
 }
 
 func TestAddrAllowedMixed(t *testing.T) {
-	allowedAddrs := []string{"app@example.com", "appsrv.example.com"}
+	allowedAddrs := []string{"app", "app@example.com", "@appsrv.example.com"}
+	if !addrAllowed("app", allowedAddrs) {
+		t.FailNow()
+	}
 	if !addrAllowed("app@example.com", allowedAddrs) {
 		t.FailNow()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,21 @@ func TestAddrAllowedSingle(t *testing.T) {
 	}
 }
 
+func TestAddrAllowedDifferentCase(t *testing.T) {
+	allowedAddrs := []string{"joe@abc.com"}
+    testAddrs := []string{
+        "joe@ABC.com",
+        "Joe@abc.com",
+        "JOE@abc.com",
+        "JOE@ABC.COM",
+    }
+    for _, addr := range testAddrs {
+        if !addrAllowed(addr, allowedAddrs) {
+            t.Errorf("Address %v not allowed, but should be", addr)
+        }
+    }
+}
+
 func TestAddrAllowedMulti(t *testing.T) {
 	allowedAddrs := []string{"joe@abc.com", "bob@def.com"}
 	if !addrAllowed("joe@abc.com", allowedAddrs) {

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -42,9 +42,9 @@
 ;   bcrypt-hash: The bcrypt hash of the pasword (generate with "./hasher password")
 ;   email: Comma-separated list of allowed "from" addresses:
 ;          - If omitted, user can send from any address
-;          - If a domain is given, user can send from any address @ that domain
-;          - Otherwise, email address must match
-;          E.g. "app@example.com,appsrv.example.com"
+;          - If @domain.com is given, user can send from any address @domain.com
+;          - Otherwise, email address must match exactly (case-insensitive)
+;          E.g. "app@example.com,@appsrv.example.com"
 ;allowed_users =
 
 ; Relay all mails to this SMTP server

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -37,7 +37,14 @@
 
 ; File which contains username and password used for
 ; authentication before they can send mail.
-; File format: username bcrypt-hash [email]
+; File format: username bcrypt-hash [email[,email[,...]]]
+;   username: The SMTP auth username
+;   bcrypt-hash: The bcrypt hash of the pasword (generate with "./hasher password")
+;   email: Comma-separated list of allowed "from" addresses:
+;          - If omitted, user can send from any address
+;          - If a domain is given, user can send from any address @ that domain
+;          - Otherwise, email address must match
+;          E.g. "app@example.com,appsrv.example.com"
 ;allowed_users =
 
 ; Relay all mails to this SMTP server


### PR DESCRIPTION
This closes #8 and implements Option 1.

In addition to the unit tests, this has been tested in production with the following sample:

```ini
appsrv $2a$10$xxxxxxx app@example.com,appsrv.internal.example.com
```

Then I attempted to send mail (`sendmail`):
- As `root` Linux user
  - `sendmail -r app@example.com me@gmail.com` :heavy_check_mark: 
  - `sendmail  me@gmail.com` (effective address: `root@appsrv.internal.example.com`) :heavy_check_mark: 
  - `sendmail -r not-app@example.com me@gmail.com` :x: (failed, as expected)
- As `jreinhart` Linux user:
  - `sendmail me@gmail.com` (effective address: `jreinhart@appsrv.internal.example.com`) :heavy_check_mark: 