### PR TITLE
Minor cleanup and fixes

### DIFF
--- a/cmd/hasher.go
+++ b/cmd/hasher.go
@@ -8,11 +8,15 @@ import (
 )
 
 func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "Usage: hasher PASSWORD")
+		os.Exit(1)
+	}
 	password := os.Args[1]
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		fmt.Println("Error generating hash: %s", err)
+		fmt.Fprintln(os.Stderr, "Error generating hash: %s", err)
 	}
 	fmt.Println(string(hash))
 }

--- a/main.go
+++ b/main.go
@@ -257,11 +257,9 @@ func main() {
 		log.SetOutput(io.MultiWriter(os.Stdout, f))
 	}
 
-	listeners := strings.Split(*listen, " ")
 
-	for i := range listeners {
-		listener := listeners[i]
-
+	// Create a server for each desired listen address
+	for _, listenAddr := range strings.Split(*listen, " ") {
 		server := &smtpd.Server{
 			Hostname:          *hostName,
 			WelcomeMessage:    *welcomeMsg,
@@ -283,27 +281,27 @@ func main() {
 		var lsnr net.Listener
 		var err error
 
-		if strings.Index(listeners[i], "://") == -1 {
-			log.Printf("Listen on %s ...\n", listener)
+		if strings.Index(listenAddr, "://") == -1 {
+			log.Printf("Listen on %s ...\n", listenAddr)
 
-			lsnr, err = net.Listen("tcp", listener)
-		} else if strings.HasPrefix(listeners[i], "starttls://") {
-			listener = strings.TrimPrefix(listener, "starttls://")
+			lsnr, err = net.Listen("tcp", listenAddr)
+		} else if strings.HasPrefix(listenAddr, "starttls://") {
+			listenAddr = strings.TrimPrefix(listenAddr, "starttls://")
 
 			server.TLSConfig = getTLSConfig()
 			server.ForceTLS = *localForceTLS
 
-			log.Printf("Listen on %s (STARTTLS) ...\n", listener)
-			lsnr, err = net.Listen("tcp", listener)
-		} else if strings.HasPrefix(listeners[i], "tls://") {
-			listener = strings.TrimPrefix(listener, "tls://")
+			log.Printf("Listen on %s (STARTTLS) ...\n", listenAddr)
+			lsnr, err = net.Listen("tcp", listenAddr)
+		} else if strings.HasPrefix(listenAddr, "tls://") {
+			listenAddr = strings.TrimPrefix(listenAddr, "tls://")
 
 			server.TLSConfig = getTLSConfig()
 
-			log.Printf("Listen on %s (TLS) ...\n", listener)
-			lsnr, err = tls.Listen("tcp", listener, server.TLSConfig)
+			log.Printf("Listen on %s (TLS) ...\n", listenAddr)
+			lsnr, err = tls.Listen("tcp", listenAddr, server.TLSConfig)
 		} else {
-			log.Fatal("Unknown protocol in listener ", listener)
+			log.Fatal("Unknown protocol in listen address ", listenAddr)
 		}
 
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -257,6 +257,13 @@ func main() {
 		log.SetOutput(io.MultiWriter(os.Stdout, f))
 	}
 
+	// Load allowed users file
+	if *allowedUsers != "" {
+		err := AuthLoadFile(*allowedUsers)
+		if err != nil {
+			log.Fatalf("Authentication file: %s\n", err)
+		}
+	}
 
 	// Create a server for each desired listen address
 	for _, listenAddr := range strings.Split(*listen, " ") {
@@ -270,11 +277,6 @@ func main() {
 		}
 
 		if *allowedUsers != "" {
-			err := AuthLoadFile(*allowedUsers)
-			if err != nil {
-				log.Fatalf("Authentication file: %s\n", err)
-			}
-
 			server.Authenticator = authChecker
 		}
 

--- a/main.go
+++ b/main.go
@@ -274,7 +274,14 @@ func main() {
 
 		if strings.Index(listeners[i], "://") == -1 {
 			log.Printf("Listen on %s ...\n", listener)
-			go server.ListenAndServe(listener)
+
+			lsnr, err := net.Listen("tcp", listener)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer lsnr.Close()
+
+			go server.Serve(lsnr)
 		} else if strings.HasPrefix(listeners[i], "starttls://") {
 			listener = strings.TrimPrefix(listener, "starttls://")
 

--- a/main.go
+++ b/main.go
@@ -272,16 +272,13 @@ func main() {
 			server.Authenticator = authChecker
 		}
 
+		var lsnr net.Listener
+		var err error
+
 		if strings.Index(listeners[i], "://") == -1 {
 			log.Printf("Listen on %s ...\n", listener)
 
-			lsnr, err := net.Listen("tcp", listener)
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer lsnr.Close()
-
-			go server.Serve(lsnr)
+			lsnr, err = net.Listen("tcp", listener)
 		} else if strings.HasPrefix(listeners[i], "starttls://") {
 			listener = strings.TrimPrefix(listener, "starttls://")
 
@@ -289,30 +286,24 @@ func main() {
 			server.ForceTLS = *localForceTLS
 
 			log.Printf("Listen on %s (STARTTLS) ...\n", listener)
-			lsnr, err := net.Listen("tcp", listener)
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer lsnr.Close()
-
-			go server.Serve(lsnr)
+			lsnr, err = net.Listen("tcp", listener)
 		} else if strings.HasPrefix(listeners[i], "tls://") {
-
 			listener = strings.TrimPrefix(listener, "tls://")
 
 			server.TLSConfig = getTLSConfig()
 
 			log.Printf("Listen on %s (TLS) ...\n", listener)
-			lsnr, err := tls.Listen("tcp", listener, server.TLSConfig)
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer lsnr.Close()
-
-			go server.Serve(lsnr)
+			lsnr, err = tls.Listen("tcp", listener, server.TLSConfig)
 		} else {
 			log.Fatal("Unknown protocol in listener ", listener)
 		}
+
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer lsnr.Close()
+
+		go server.Serve(lsnr)
 	}
 
 	for true {


### PR DESCRIPTION
This PR makes some minor cleanup and fixes:

- Do some refactoring in `main()` to DRY up redundant code, and make it a little easier to read
- Don't run `ListenAndServe` in a go routine -- This fixes #10
- Add helpful log messages for various error cases caused by client misconfiguration
- Add command line argument checking in `hasher` (don't segfault when password arg is missing)