### PR TITLE
Allow any network and related enhancements

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,14 +17,8 @@ import (
 )
 
 func connectionChecker(peer smtpd.Peer) error {
-	var peerIP net.IP
-	if addr, ok := peer.Addr.(*net.TCPAddr); ok {
-		peerIP = net.ParseIP(addr.IP.String())
-	} else {
-		log.WithField("ip", addr.IP).
-			Warn("failed to parse IP")
-		return smtpd.Error{Code: 421, Message: "Denied"}
-	}
+	// This can't panic because we only have TCP listeners
+	peerIP := peer.Addr.(*net.TCPAddr).IP
 
 	nets := strings.Split(*allowedNets, " ")
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,10 @@ func connectionChecker(peer smtpd.Peer) error {
 	// This can't panic because we only have TCP listeners
 	peerIP := peer.Addr.(*net.TCPAddr).IP
 
+	if len(allowedNets) == 0 {
+		// Special case: empty string means allow everything
+		return nil
+	}
 
 	for _, allowedNet := range allowedNets {
 		if allowedNet.Contains(peerIP) {

--- a/main.go
+++ b/main.go
@@ -20,11 +20,8 @@ func connectionChecker(peer smtpd.Peer) error {
 	// This can't panic because we only have TCP listeners
 	peerIP := peer.Addr.(*net.TCPAddr).IP
 
-	nets := strings.Split(*allowedNets, " ")
 
-	for i := range nets {
-		_, allowedNet, _ := net.ParseCIDR(nets[i])
-
+	for _, allowedNet := range allowedNets {
 		if allowedNet.Contains(peerIP) {
 			return nil
 		}

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -31,6 +31,7 @@
 ;local_forcetls = false
 
 ; Networks that are allowed to send mails to us
+; Defaults to localhost. If set to "", then any address is allowed.
 ;allowed_nets = 127.0.0.1/8 ::1/128
 
 ; Regular expression for valid FROM EMail addresses

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -32,7 +32,7 @@
 
 ; Networks that are allowed to send mails to us
 ; Defaults to localhost. If set to "", then any address is allowed.
-;allowed_nets = 127.0.0.1/8 ::1/128
+;allowed_nets = 127.0.0.0/8 ::1/128
 
 ; Regular expression for valid FROM EMail addresses
 ; Example: ^(.*)@localhost.localdomain$


### PR DESCRIPTION
This PR allows the `allowed_nets` config option to be an empty string which means "any network", without having to enter `0.0.0.0/0 ::/0`.

It also re-works the way `allowed_nets` is parsed to make several improvements:
- Consecutive spaces are ignored
- Errors from invalid CIDR notations are now caught
- It is parsed at startup instead of at runtime.

This PR is a result of discussions on #13 and is inspired by grafana#4.

Follows #15.