### PR TITLE
Move remaining config option parsing to ConfigLoad()

### DIFF
--- a/config.go
+++ b/config.go
@@ -91,8 +91,7 @@ func setupRemoteAuth() {
 	logger := log.WithField("remote_auth", *remoteAuthStr)
 
 	// Remote auth disabled?
-	switch *remoteAuthStr {
-	case "", "none":
+	if *remoteAuthStr == "" || *remoteAuthStr == "none" {
 		if *remoteUser != "" {
 			logger.Fatal("remote_user given but not used")
 		}

--- a/config.go
+++ b/config.go
@@ -28,7 +28,8 @@ var (
 	allowedNets       = []*net.IPNet{}
 	allowedSenderStr  = flag.String("allowed_sender", "", "Regular expression for valid FROM EMail addresses")
 	allowedSender     *regexp.Regexp
-	allowedRecipients = flag.String("allowed_recipients", "", "Regular expression for valid TO EMail addresses")
+	allowedRecipStr   = flag.String("allowed_recipients", "", "Regular expression for valid TO EMail addresses")
+	allowedRecipients *regexp.Regexp
 	allowedUsers      = flag.String("allowed_users", "", "Path to file with valid users/passwords")
 	remoteHost        = flag.String("remote_host", "", "Outgoing SMTP server")
 	remoteUser        = flag.String("remote_user", "", "Username for authentication on outgoing SMTP server")
@@ -61,17 +62,25 @@ func setupAllowedNetworks() {
 	}
 }
 
-func setupAllowedSender() {
-	if (*allowedSenderStr == "") {
-		return
+func setupAllowedPatterns() {
+	var err error
+
+	if (*allowedSenderStr != "") {
+		allowedSender, err = regexp.Compile(*allowedSenderStr)
+		if err != nil {
+			log.WithField("allowed_sender", *allowedSenderStr).
+				WithError(err).
+				Fatal("allowed_sender pattern invalid")
+		}
 	}
 
-	var err error
-	allowedSender, err = regexp.Compile(*allowedSenderStr)
-	if err != nil {
-		log.WithField("allowed_sender", *allowedSenderStr).
-			WithError(err).
-			Fatal("allowed_sender pattern invalid")
+	if (*allowedRecipStr != "") {
+		allowedRecipients, err = regexp.Compile(*allowedRecipStr)
+		if err != nil {
+			log.WithField("allowed_recipients", *allowedRecipStr).
+				WithError(err).
+				Fatal("allowed_recipients pattern invalid")
+		}
 	}
 }
 
@@ -86,5 +95,5 @@ func ConfigLoad() {
 	}
 
 	setupAllowedNetworks()
-	setupAllowedSender()
+	setupAllowedPatterns()
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/smtp"
 	"net/textproto"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -121,19 +120,13 @@ func senderChecker(peer smtpd.Peer, addr string) error {
 }
 
 func recipientChecker(peer smtpd.Peer, addr string) error {
-	if *allowedRecipients == "" {
+	if allowedRecipients == nil {
+		// Any recipient is permitted
 		return nil
 	}
 
-	re, err := regexp.Compile(*allowedRecipients)
-	if err != nil {
-		log.WithFields(logrus.Fields{
-			"allowed_recipients": *allowedRecipients,
-		}).WithError(err).Warn("allowed_recipients pattern invalid")
-		return smtpd.Error{Code: 451, Message: "Bad recipient address"}
-	}
-
-	if re.MatchString(addr) {
+	if allowedRecipients.MatchString(addr) {
+		// Permitted by regex
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"net/smtp"
 	"net/textproto"
 	"os"
 	"strings"
@@ -170,20 +169,6 @@ func mailHandler(peer smtpd.Peer, env smtpd.Envelope) error {
 
 	logger.Info("delivering mail from peer using smarthost")
 
-	var auth smtp.Auth
-	host, _, _ := net.SplitHostPort(*remoteHost)
-
-	if *remoteUser != "" && *remotePass != "" {
-		switch *remoteAuth {
-		case "plain":
-			auth = smtp.PlainAuth("", *remoteUser, *remotePass, host)
-		case "login":
-			auth = LoginAuth(*remoteUser, *remotePass)
-		default:
-			return smtpd.Error{Code: 530, Message: "Authentication method not supported"}
-		}
-	}
-
 	env.AddReceivedLine(peer)
 
 	var sender string
@@ -196,7 +181,7 @@ func mailHandler(peer smtpd.Peer, env smtpd.Envelope) error {
 
 	err := SendMail(
 		*remoteHost,
-		auth,
+		remoteAuth,
 		sender,
 		env.Recipients,
 		env.Data,

--- a/main.go
+++ b/main.go
@@ -103,26 +103,20 @@ func senderChecker(peer smtpd.Peer, addr string) error {
 		}
 	}
 
-	if *allowedSender == "" {
+	if allowedSender == nil {
+		// Any sender is permitted
 		return nil
 	}
 
-	re, err := regexp.Compile(*allowedSender)
-	if err != nil {
-		log.WithFields(logrus.Fields{
-			"allowed_sender": *allowedSender,
-		}).WithError(err).Warn("allowed_sender pattern invalid")
-		return smtpd.Error{Code: 451, Message: "Bad sender address"}
-	}
-
-	if re.MatchString(addr) {
+	if allowedSender.MatchString(addr) {
+		// Permitted by regex
 		return nil
 	}
 
 	log.WithFields(logrus.Fields{
 		"sender_address": addr,
 		"peer": peer.Addr,
-	}).Warn("Sender address not allowed by allowed_sender pattern")
+	}).Warn("sender address not allowed by allowed_sender pattern")
 	return smtpd.Error{Code: 451, Message: "Bad sender address"}
 }
 

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -73,8 +73,8 @@
 ;remote_pass =
 
 ; Authentication method on outgoing SMTP server
-; (plain, login)
-;remote_auth = plain
+; (none, plain, login)
+;remote_auth = none
 
 ; Sender e-mail address on outgoing SMTP server
 ;remote_sender = 

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -35,10 +35,12 @@
 ;allowed_nets = 127.0.0.0/8 ::1/128
 
 ; Regular expression for valid FROM EMail addresses
+; If set to "", then any sender is permitted.
 ; Example: ^(.*)@localhost.localdomain$
 ;allowed_sender =
 
 ; Regular expression for valid TO EMail addresses
+; If set to "", then any recipient is permitted.
 ; Example: ^(.*)@localhost.localdomain$
 ;allowed_recipients =
 


### PR DESCRIPTION
Move remaining parsing of config options from server callbacks to `ConfigLoad()`:
- `allowed_sender` regex compilation
- `allowed_recipients` regex compilation
- SMTP auth setup and validation (`remote_auth`, `remote_user`, `remote_password`)

With this change, we can catch configuration errors during startup and avoid an error case during connection handling.

This also introduces a `none` type for `remote_auth`, and makes it the default. This is a more explicit equivalent of an empty username/password before this change.

This was identified during review of #13 and implementation of #15.