### PR TITLE
Don't allow configuration requiring authentication with non-TLS listener

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,10 @@ var (
 	versionInfo       = flag.Bool("version", false, "Show version information")
 )
 
+func localAuthRequired() bool {
+	return *allowedUsers != ""
+}
+
 
 func setupAllowedNetworks() {
 	for _, netstr := range splitstr(*allowedNetsStr, ' ') {

--- a/config.go
+++ b/config.go
@@ -157,6 +157,14 @@ func splitProto(s string) protoAddr {
 func setupListeners() {
 	for _, listenAddr := range strings.Split(*listenStr, " ") {
 		pa := splitProto(listenAddr)
+
+		if localAuthRequired() && pa.protocol == "" {
+			log.WithField("address", pa.address).
+				Fatal("Local authentication (via allowed_users file) " +
+				      "not allowed with non-TLS listener")
+		}
+
+
 		listenAddrs = append(listenAddrs, pa)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSplitProto(t *testing.T) {
+	var tests = []struct {
+		input      string
+		proto      string
+		addr       string
+	}{
+		{
+			input:      "localhost",
+			proto:      "",
+			addr:       "localhost",
+		},
+		{
+			input:      "tls://my.local.domain",
+			proto:      "tls",
+			addr:       "my.local.domain",
+		},
+		{
+			input:      "starttls://my.local.domain",
+			proto:      "starttls",
+			addr:       "my.local.domain",
+		},
+	}
+
+	for i, test := range tests {
+		testName := test.input
+		t.Run(testName, func(t *testing.T) {
+			pa := splitProto(test.input)
+			if pa.protocol != test.proto {
+				t.Errorf("Testcase %d: Incorrect proto: expected %v, got %v",
+					i, test.proto, pa.protocol)
+			}
+			if pa.address != test.addr {
+				t.Errorf("Testcase %d: Incorrect addr: expected %v, got %v",
+					i, test.addr, pa.address)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func addrAllowed(addr string, allowedAddrs []string) bool {
 
 func senderChecker(peer smtpd.Peer, addr string) error {
 	// check sender address from auth file if user is authenticated
-	if *allowedUsers != "" && peer.Username != "" {
+	if localAuthRequired() && peer.Username != "" {
 		user, err := AuthFetch(peer.Username)
 		if err != nil {
 			// Shouldn't happen: authChecker already validated username+password
@@ -276,7 +276,7 @@ func main() {
 		Debug("starting smtprelay")
 
 	// Load allowed users file
-	if *allowedUsers != "" {
+	if localAuthRequired() {
 		err := AuthLoadFile(*allowedUsers)
 		if err != nil {
 			log.WithField("file", *allowedUsers).
@@ -300,7 +300,7 @@ func main() {
 			Handler:           mailHandler,
 		}
 
-		if *allowedUsers != "" {
+		if localAuthRequired() {
 			server.Authenticator = authChecker
 		}
 


### PR DESCRIPTION
This fixes #26.

Now if someone tries to run `smtprelay` with `-allowed_users` and any non-TLS address in `-listen`, it will fail right away:
```
$ ./smtprelay -listen ':2525' -allowed_users userlist.txt 
WARN[2021-04-01T01:03:57-04:00] remote_host not set; mail will not be forwarded! 
FATA[2021-04-01T01:03:57-04:00] Local authentication (via allowed_users file) not allowed with non-TLS listener  address=":2525"
```