### PR TITLE
Add external command support

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ var (
 	allowedRecipStr   = flag.String("allowed_recipients", "", "Regular expression for valid TO EMail addresses")
 	allowedRecipients *regexp.Regexp
 	allowedUsers      = flag.String("allowed_users", "", "Path to file with valid users/passwords")
+	command           = flag.String("command", "", "Path to pipe command")
 	remoteHost        = flag.String("remote_host", "", "Outgoing SMTP server")
 	remoteUser        = flag.String("remote_user", "", "Username for authentication on outgoing SMTP server")
 	remotePass        = flag.String("remote_pass", "", "Password for authentication on outgoing SMTP server")
@@ -172,8 +173,8 @@ func ConfigLoad() {
 	// Set up logging as soon as possible
 	setupLogger()
 
-	if *remoteHost == "" {
-		log.Warn("remote_host not set; mail will not be forwarded!")
+	if *remoteHost == "" && *command == "" {
+		log.Warn("no remote_host or command set; mail will not be forwarded!")
 	}
 
 	setupAllowedNetworks()

--- a/main.go
+++ b/main.go
@@ -170,6 +170,8 @@ func mailHandler(peer smtpd.Peer, env smtpd.Envelope) error {
 		return nil
 	}
 
+	env.AddReceivedLine(peer)
+
 	if *command != "" {
 		cmdLogger := logger.WithField("command", *command)
 
@@ -195,8 +197,6 @@ func mailHandler(peer smtpd.Peer, env smtpd.Envelope) error {
 	}
 
 	logger.Info("delivering mail from peer using smarthost")
-
-	env.AddReceivedLine(peer)
 
 	var sender string
 

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -78,3 +78,6 @@
 
 ; Sender e-mail address on outgoing SMTP server
 ;remote_sender = 
+
+; Pipe messages to external command
+;command = /usr/local/bin/script


### PR DESCRIPTION
Hi,

I attempted to implement #32.

This adds a way to pipe emails to an external command, similar to [pipe(8)](http://www.postfix.org/pipe.8.html) from Postfix.

This is configured with a new `command` option like:

```
command = /path/to/script 
```

I'd happily accept any feedback on the implementation as this is the first go I've written.

No worries if this is not a good fit for the project.

Thanks!

