### PR TITLE
Propagate the error to the client if the external command fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,7 +186,10 @@ func mailHandler(peer smtpd.Peer, env smtpd.Envelope) error {
 		err := cmd.Run()
 		if err != nil {
 			cmdLogger.WithError(err).Error(stderr.String())
-			return nil
+			return smtpd.Error{
+				Code:    554,
+				Message: "external sender error, contact your SMTP administrator",
+			}
 		}
 
 		cmdLogger.Info("pipe command successful: " + stdout.String())

--- a/main.go
+++ b/main.go
@@ -186,10 +186,7 @@ func mailHandler(peer smtpd.Peer, env smtpd.Envelope) error {
 		err := cmd.Run()
 		if err != nil {
 			cmdLogger.WithError(err).Error(stderr.String())
-			return smtpd.Error{
-				Code:    554,
-				Message: "external sender error, contact your SMTP administrator",
-			}
+			return smtpd.Error{Code: 554, Message: "External command failed"}
 		}
 
 		cmdLogger.Info("pipe command successful: " + stdout.String())


### PR DESCRIPTION
This change makes the external command code return a generic 554 error to the SMTP client if the external command fails, so it knows sending failed and can retry.