### PR TITLE
add: basic smtpd configuration options

### DIFF
--- a/main.go
+++ b/main.go
@@ -320,6 +320,12 @@ func main() {
 		server := &smtpd.Server{
 			Hostname:          *hostName,
 			WelcomeMessage:    *welcomeMsg,
+			ReadTimeout:       readTimeout,
+			WriteTimeout:      writeTimeout,
+			DataTimeout:       dataTimeout,
+			MaxConnections:    *maxConnections,
+			MaxMessageSize:    *maxMessageSize,
+			MaxRecipients:     *maxRecipients,
 			ConnectionChecker: connectionChecker,
 			SenderChecker:     senderChecker,
 			RecipientChecker:  recipientChecker,

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -30,6 +30,33 @@
 ; accepting mails from client.
 ;local_forcetls = false
 
+; Socket timeout for read operations
+; Duration string as sequence of decimal numbers,
+; each with optional fraction and a unit suffix.
+; Valid time units are "ns", "us", "ms", "s", "m", "h".
+;read_timeout = 60s
+
+; Socket timeout for write operations
+; Duration string as sequence of decimal numbers,
+; each with optional fraction and a unit suffix.
+; Valid time units are "ns", "us", "ms", "s", "m", "h".
+;write_timeout = 60s
+
+; Socket timeout for DATA command
+; Duration string as sequence of decimal numbers,
+; each with optional fraction and a unit suffix.
+; Valid time units are "ns", "us", "ms", "s", "m", "h".
+;data_timeout = 5m
+
+; Max concurrent connections, use -1 to disable
+;max_connections = 100
+
+; Max message size in bytes
+;max_message_size = 10240000
+
+; Max RCPT TO calls for each envelope
+;max_recipients = 100
+
 ; Networks that are allowed to send mails to us
 ; Defaults to localhost. If set to "", then any address is allowed.
 ;allowed_nets = 127.0.0.0/8 ::1/128


### PR DESCRIPTION
This adds the basic configuration options `ReadTimeout`, `WriteTimeout`, `DataTimeout`, `MaxConnections`, `MaxMessageSize`, and `MaxRecipients`, which are exposed by [smtpd](https://github.com/chrj/smtpd/blob/166abaf187f20fff6fab584a577ac66dc4b667f2/smtpd.go#L18). Closes #37.

As this is my first commit ever in go, please let me know if I could improve on anything :)

Thanks for this great little piece of software!