### PR TITLE
Cerothen patch 1

### DIFF
--- a/smtp.go
+++ b/smtp.go
@@ -322,6 +322,11 @@ var testHookStartTLS func(*tls.Config) // nil, except for tests
 // library.
 func SendMail(r *Remote, from string, to []string, msg []byte) error {
 	if r.Sender != "" {
+		// Update the message headers
+		regexSearch := regexp.MustCompile("([Ff]rom:[\t ]+(?:[^\t ]+[\t ]+)?<?)"+regexp.QuoteMeta(from)+"(>)?\n")
+		regexReplace := "${1}"+r.Sender+"${2}\n"
+		msg = []byte(regexSearch.ReplaceAllString(string(msg), regexReplace))
+		// Update the from attribute
 		from = r.Sender
 	}
 

--- a/smtp.go
+++ b/smtp.go
@@ -27,6 +27,7 @@ import (
 	"net/smtp"
 	"net/textproto"
 	"strings"
+	"regexp"
 )
 
 // A Client represents a client connection to an SMTP server.


### PR DESCRIPTION
Resolve issue 134
https://github.com/decke/smtprelay/issues/134

Some mail providers (proton in this case) reject the mail if the msg content isnt updated to reflect an updated "From: " header.

This pull request modifies the from header while preserving additional naming data (it does not correct malformed data)

```From: original@host.tld``` => ```From: updated@newhost.tld```

OR

```From: Some Name <original@host.tld>``` => ```From: Some Name <updated@newhost.tld>```