### PR TITLE
set transient response code on potential temporary error conditions

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func mailHandler(peer smtpd.Peer, env smtpd.Envelope) error {
 					"err_msg":  err.Msg,
 				}).Error("delivery failed")
 			default:
-				smtpError = smtpd.Error{Code: 554, Message: "Forwarding failed"}
+				smtpError = smtpd.Error{Code: 421, Message: "Forwarding failed"}
 
 				logger.WithError(err).
 					Error("delivery failed")


### PR DESCRIPTION
Unkown errors may be caused by temporary error conditions, e.g. socket errors (DNS errors, network interruptions, ...), but smtprelay responds with a final SMTP error code. Since final SMTP error codes leads to a different behavior of correct working clients (bounce instead of retry), a 5xx response signals clients to give up on a specific mail instead of retrying a later delivery. This is not correct for temporary error conditions, so smtprelay should respond with a 4xx transient error code.

I think SMTP error code 421 is a more proper response for unkown conditions, that prevents smtprelay to forward an mail.

https://www.cloudmailin.com/smtp-troubleshooter/421-error