### PR TITLE
Cleanup getTLSConfig() and also remove custom cipher list

### DIFF
--- a/main.go
+++ b/main.go
@@ -267,22 +267,6 @@ func generateUUID() string {
 }
 
 func getTLSConfig() *tls.Config {
-	// Ciphersuites as defined in stock Go but without 3DES and RC4
-	// https://golang.org/src/crypto/tls/cipher_suites.go
-	var tlsCipherSuites = []uint16{
-		tls.TLS_AES_128_GCM_SHA256,
-		tls.TLS_AES_256_GCM_SHA384,
-		tls.TLS_CHACHA20_POLY1305_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256, // does not provide PFS
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384, // does not provide PFS
-	}
-
 	if *localCert == "" || *localKey == "" {
 		log.Fatal().
 			Str("cert_file", *localCert).
@@ -298,10 +282,7 @@ func getTLSConfig() *tls.Config {
 	}
 
 	return &tls.Config{
-		PreferServerCipherSuites: true,
-		MinVersion:               tls.VersionTLS12,
-		CipherSuites:             tlsCipherSuites,
-		Certificates:             []tls.Certificate{cert},
+		Certificates: []tls.Certificate{cert},
 	}
 }
 


### PR DESCRIPTION
With modern Go (>=1.17) this is mostly a NOOP except CBC ciphers/ LUCKY13. Since Go has mitigations against LUCKY13 this in fact improves our client compatbility and is safe to use.

See:	https://github.com/golang/go/issues/13385