### PR TITLE
Client certificate for relay connections

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,8 @@ var (
 	command          = flagset.String("command", "", "Path to pipe command")
 	remotesStr       = flagset.String("remotes", "", "Outgoing SMTP servers")
 	strictSender     = flagset.Bool("strict_sender", false, "Use only SMTP servers with Sender matches to From")
+	remoteCert       = flagset.String("remote_certificate", "", "Client SSL certificate for remote STARTTLS/TLS")
+	remoteKey        = flagset.String("remote_key", "", "Client SSL private key for remote STARTTLS/TLS")
 
 	// additional flags
 	_           = flagset.String("config", "", "Path to config file (ini format)")
@@ -65,6 +67,36 @@ var (
 
 func localAuthRequired() bool {
 	return *allowedUsers != ""
+}
+
+func remoteCertAndKeyReadable() bool {
+	certSet := *remoteCert != ""
+	keySet := *remoteKey != ""
+	
+	// Both must be set or both must be unset
+	if certSet != keySet {
+		return false
+	}
+	
+	// If both are set, verify files exist and are accessible
+	if certSet && keySet {
+		if _, err := os.Stat(*remoteCert); err != nil {
+			log.Error().
+				Str("cert", *remoteCert).
+				Err(err).
+				Msg("cannot access remote client certificate file")
+			return false
+		}
+		if _, err := os.Stat(*remoteKey); err != nil {
+			log.Error().
+				Str("key", *remoteKey).
+				Err(err).
+				Msg("cannot access remote client key file")
+			return false
+		}
+	}
+	
+	return true
 }
 
 func setupAliases() {
@@ -136,6 +168,11 @@ func setupRemotes() {
 			r, err := ParseRemote(remoteURL)
 			if err != nil {
 				logger.Fatal().Msg(fmt.Sprintf("error parsing url: '%s': %v", remoteURL, err))
+			}
+
+			if *remoteCert != "" && *remoteKey != "" && (r.Scheme == "smtps" || r.Scheme == "starttls") {
+				r.ClientCertPath = *remoteCert
+				r.ClientKeyPath = *remoteKey
 			}
 
 			remotes = append(remotes, r)
@@ -252,6 +289,13 @@ func ConfigLoad() {
 
 	if *remotesStr == "" && *command == "" {
 		log.Warn().Msg("no remotes or command set; mail will not be forwarded!")
+	}
+
+	if !remoteCertAndKeyReadable() {
+		log.Fatal().
+			Str("remote_certificate", *remoteCert).
+			Str("remote_key", *remoteKey).
+			Msg("remote_certificate and remote_key must both be set or both be empty")
 	}
 
 	setupAllowedNetworks()

--- a/remotes.go
+++ b/remotes.go
@@ -7,13 +7,15 @@ import (
 )
 
 type Remote struct {
-	SkipVerify bool
-	Auth       smtp.Auth
-	Scheme     string
-	Hostname   string
-	Port       string
-	Addr       string
-	Sender     string
+	SkipVerify      bool
+	Auth            smtp.Auth
+	Scheme          string
+	Hostname        string
+	Port            string
+	Addr            string
+	Sender          string
+	ClientCertPath  string
+	ClientKeyPath   string
 }
 
 // ParseRemote creates a remote from a given url in the following format:

--- a/smtp.go
+++ b/smtp.go
@@ -340,6 +340,14 @@ func SendMail(r *Remote, from string, to []string, msg []byte) error {
 			ServerName:         r.Hostname,
 			InsecureSkipVerify: r.SkipVerify,
 		}
+		// Load client certificate on-demand, just before connection
+		if r.ClientCertPath != "" && r.ClientKeyPath != "" {
+			cert, err := tls.LoadX509KeyPair(r.ClientCertPath, r.ClientKeyPath)
+			if err != nil {
+				return err
+			}
+			config.Certificates = []tls.Certificate{cert}
+		}
 		conn, err := tls.Dial("tcp", r.Addr, config)
 		if err != nil {
 			return err
@@ -365,6 +373,14 @@ func SendMail(r *Remote, from string, to []string, msg []byte) error {
 			config := &tls.Config{
 				ServerName:         c.serverName,
 				InsecureSkipVerify: r.SkipVerify,
+			}
+			// Load client certificate on-demand, just before use
+			if r.ClientCertPath != "" && r.ClientKeyPath != "" {
+				cert, err := tls.LoadX509KeyPair(r.ClientCertPath, r.ClientKeyPath)
+				if err != nil {
+					return err
+				}
+				config.Certificates = []tls.Certificate{cert}
 			}
 			if testHookStartTLS != nil {
 				testHookStartTLS(config)

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -119,6 +119,10 @@
 ; Mailjet.com
 ;remotes = starttls://user:pass@in-v3.mailjet.com:587
 
+; Exchange Online (O365) SMTP relay
+; (Change netloc to your own Exchange MX endpoint)
+; remotes = starttls://contoso-com.mail.protection.outlook.com:25
+
 ; Ignore remote host certificates
 ;remotes = starttls://user:pass@server:587?skipVerify
 
@@ -130,6 +134,12 @@
 
 ; Multiple remotes, space delimited
 ;remotes = smtp://127.0.0.1:1025 starttls://user:pass@smtp.mailgun.org:587
+
+; Client SSL certificate for remote STARTTLS/TLS
+; remote_certificate = /path/to/certificate-chain.pem
+
+; Client SSL private key for remote STARTTLS/TLS
+; remote_key = /path/to/private-key.pem
 
 ; Pipe messages to external command
 ;command = /usr/local/bin/script


### PR DESCRIPTION
- Add options remote_certificate and remote_key to config
- Verify values are paths and readable
- Construct required certificate on-demand before connecting upstream (during mail relay)

This code has been end-to-end tested with an Exchange SMTP relay setup and works.

Fixes #185 