### PR TITLE
Add configurable TLS profiles for listeners

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ var (
 	listenStr        = flagset.String("listen", "127.0.0.1:25 [::1]:25", "Address and port to listen for incoming SMTP")
 	localCert        = flagset.String("local_cert", "", "SSL certificate for STARTTLS/TLS")
 	localKey         = flagset.String("local_key", "", "SSL private key for STARTTLS/TLS")
+	tlsProfile       = flagset.String("tls_profile", "default", "TLS profile: modern | intermediate | default | legacy")
 	localForceTLS    = flagset.Bool("local_forcetls", false, "Force STARTTLS (needs local_cert and local_key)")
 	readTimeoutStr   = flagset.String("read_timeout", "60s", "Socket timeout for read operations")
 	writeTimeoutStr  = flagset.String("write_timeout", "60s", "Socket timeout for write operations")

--- a/main.go
+++ b/main.go
@@ -281,6 +281,7 @@ func generateUUID() string {
 }
 
 func getTLSConfig() *tls.Config {
+	// Certificate loading / validation
 	if *localCert == "" || *localKey == "" {
 		log.Fatal().
 			Str("cert_file", *localCert).
@@ -295,9 +296,60 @@ func getTLSConfig() *tls.Config {
 			Msg("cannot load X509 keypair")
 	}
 
-	return &tls.Config{
+	// TLS profile configuration
+	// tls.Config.CipherSuites only affects TLS 1.0–1.2.
+
+	// Base config: Go defaults unless overridden.
+	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 	}
+
+	profile := strings.ToLower(strings.TrimSpace(*tlsProfile))
+	if profile == "" {
+		profile = "default"
+	}
+
+	switch profile {
+	case "default":
+		// Go defaults (leave MinVersion/MaxVersion/CipherSuites unset).
+
+	case "modern":
+		// TLS 1.3+.
+		conf.MinVersion = tls.VersionTLS13
+
+	case "intermediate":
+		// TLS 1.2+ with AEAD + ECDHE cipher suites only.
+		// Mozilla "intermediate" — AEAD + ECDHE only.
+		conf.MinVersion = tls.VersionTLS12
+		conf.CipherSuites = []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		}
+
+	case "legacy":
+		// Last resort: TLS 1.0+ and everything Go exposes for TLS 1.0–1.2.
+		conf.MinVersion = tls.VersionTLS10
+
+		allSuites := []uint16{}
+		for _, cs := range tls.CipherSuites() {
+			allSuites = append(allSuites, cs.ID)
+		}
+		for _, cs := range tls.InsecureCipherSuites() {
+			allSuites = append(allSuites, cs.ID)
+		}
+		conf.CipherSuites = allSuites
+
+	default:
+		log.Warn().
+			Str("tls_profile", profile).
+			Msg("unknown tls_profile; using default")
+	}
+
+	return conf
 }
 
 func watchAliasFile() {

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -35,6 +35,33 @@
 ;local_cert = smtpd.pem
 ;local_key  = smtpd.key
 
+; TLS PROFILE (STARTTLS / TLS listeners)
+; Controls the minimum TLS version and allowed cipher suites for inbound
+; connections when using listen protocols `starttls://` or `tls://`.
+; Profiles follow the Mozilla SSL Configuration Generator guidelines.
+;
+;   default
+;     Go standard library defaults. Tracks improvements as Go updates
+;     its TLS defaults. Recommended for most deployments.
+;
+;   modern
+;     TLS 1.3+ only. Simplest and most secure, but rejects any client
+;     that cannot negotiate TLS 1.3.
+;     Matches Mozilla "modern" configuration.
+;
+;   intermediate
+;     TLS 1.2+. For TLS 1.2 connections only AEAD ciphers (AES-GCM,
+;     ChaCha20-Poly1305) with ECDHE key exchange are allowed,
+;     providing forward secrecy. TLS 1.3 ciphers are always available.
+;     Matches Mozilla "intermediate" configuration.
+;
+;   legacy
+;     TLS 1.0+ with all cipher suites the Go standard library supports,
+;     including insecure ones (RC4, 3DES). Use only when you must
+;     support very old clients that cannot negotiate TLS 1.2.
+;
+;tls_profile=default
+
 ; Enforce encrypted connection on STARTTLS ports before
 ; accepting mails from client.
 ;local_forcetls = false


### PR DESCRIPTION
This PR adds a new `tls_profile` configuration option to control the TLS policy used by inbound `starttls://` and `tls://` listeners.

This is a clean re-roll of #295 on a fresh fork with a single commit. It folds in the review feedback from #295 — the `intermediateSuites` cipher list now lives inside `case "intermediate":` in `getTLSConfig()` rather than at function scope.

## Why

- Operators sometimes need to accept connections from older / embedded devices (printers, scanners, legacy appliances) that don't support modern cipher suites.
- Other operators run internet-facing relays where stricter TLS settings are required (TLS 1.3 only, or TLS 1.2+ without CBC fallback).
- SMTP over weak TLS is still preferable to plaintext SMTP — `legacy` exists for that case.

## Profiles

| Profile | Min TLS | TLS 1.2 cipher suites | Use case |
|---|---|---|---|
| `default` | (Go default) | (Go default) | Most deployments — tracks Go stdlib improvements |
| `modern` | 1.3 | none | TLS 1.3 capable clients only |
| `intermediate` | 1.2 | 6 AEAD + ECDHE only | Internet facing, forward secrecy required |
| `legacy` | 1.0 | all (including insecure) | Last resort for very old clients |

Profile names follow the [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/).

## Files

- `config.go` — adds the `tls_profile` flag (default: `default`).
- `main.go` — `getTLSConfig()` applies the selected profile.
- `smtprelay.ini` — adds a documented `tls_profile` example block.

## Mozilla guideline alignment (re-checked against current v6.0)

Mozilla released v5.8 and v6.0 since the original PR. v6.0 is now the current published guideline; the most relevant v6.0 change is that **the `old` profile was removed entirely**.

### `modern`

| | Mozilla 5.7 | 5.8 | 6.0 (current) | Our `modern` |
|---|---|---|---|---|
| TLS versions | 1.3 | 1.3 | 1.3 | 1.3+ |
| TLS 1.2 ciphers | none | none | none | none |
| Curves | X25519, P-256, P-384 | + X25519MLKEM768 | + X25519MLKEM768 | Go default |

Lines up across all three. We don't pin curves, so Go's defaults apply and pick up post-quantum support as Go adds it.

### `intermediate`

| | Mozilla 5.7 | 5.8 | 6.0 (current) | Our `intermediate` |
|---|---|---|---|---|
| TLS versions | 1.2+ | 1.2+ | 1.2+ | 1.2+ |
| ECDHE AEAD suites | 6 | 6 | 6 | 6 |
| DHE suites | 3 | 0 | 0 | 0 |

Same 6 suites across the board. Mozilla 5.7 had 3 DHE-RSA suites; Go doesn't implement DHE at all and Mozilla dropped them in 5.8.

### `legacy` vs Mozilla `old`

Mozilla **removed `old` in v6.0**. Our `legacy` is intentionally a superset of what Mozilla 5.7/5.8 `old` enabled — it turns on everything Go's standard library exposes, including `tls.InsecureCipherSuites()` (RC4, 3DES). That is documented in the `smtprelay.ini` comments and is a deliberate last-resort choice, not a Mozilla mapping.

## Notes

- TLS 1.3 cipher suites are always available regardless of profile — `tls.Config.CipherSuites` only governs TLS 1.0–1.2.
- The flag accepts surrounding whitespace and any case (`strings.ToLower(strings.TrimSpace(...))`); empty string is normalized to `default`; an unknown profile logs a warning and falls back to Go defaults.
